### PR TITLE
Create local server block with always generated self-signed cert

### DIFF
--- a/web/rootfs/defaults/local
+++ b/web/rootfs/defaults/local
@@ -9,7 +9,6 @@ server {
 	{{ end }}
 }
 
-{{ if not (.Env.DISABLE_HTTPS | default "0" | toBool) }}
 server {
 	server_name {{ .Env.XMPP_DOMAIN }};
 	listen 443 ssl http2;
@@ -17,4 +16,3 @@ server {
 	include /config/nginx/ssl-local.conf;
 	include /config/nginx/meet.conf;
 }
-{{ end }}

--- a/web/rootfs/defaults/local
+++ b/web/rootfs/defaults/local
@@ -1,0 +1,20 @@
+server {
+	server_name {{ .Env.XMPP_DOMAIN }};
+	listen 80;
+
+	{{ if .Env.ENABLE_HTTP_REDIRECT | default "0" | toBool }}
+	return 301 https://$host$request_uri;
+	{{ else }}
+	include /config/nginx/meet.conf;
+	{{ end }}
+}
+
+{{ if not (.Env.DISABLE_HTTPS | default "0" | toBool) }}
+server {
+	server_name {{ .Env.XMPP_DOMAIN }};
+	listen 443 ssl http2;
+
+	include /config/nginx/ssl-local.conf;
+	include /config/nginx/meet.conf;
+}
+{{ end }}

--- a/web/rootfs/defaults/meet.conf
+++ b/web/rootfs/defaults/meet.conf
@@ -1,5 +1,3 @@
-server_name _;
-
 client_max_body_size 0;
 
 root /usr/share/jitsi-meet;

--- a/web/rootfs/defaults/ssl-local.conf
+++ b/web/rootfs/defaults/ssl-local.conf
@@ -1,0 +1,18 @@
+# session settings
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:50m;
+ssl_session_tickets off;
+
+ssl_certificate /config/keys/cert.crt;
+ssl_certificate_key /config/keys/cert.key;
+
+# protocols
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ecdh_curve secp384r1;
+ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDH+CHACHA20:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK;
+
+# headers
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";

--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -39,18 +39,17 @@ if [[ $DISABLE_HTTPS -ne 1 ]]; then
         if [[ ! -f /etc/cron.daily/letencrypt-renew ]]; then
             cp /defaults/letsencrypt-renew /etc/cron.daily/
         fi
+    fi
+    # always create self-signed certs
+    if [[ -f /config/keys/cert.key && -f /config/keys/cert.crt ]]; then
+        echo "using keys found in /config/keys"
     else
-        # use self-signed certs
-        if [[ -f /config/keys/cert.key && -f /config/keys/cert.crt ]]; then
-            echo "using keys found in /config/keys"
-        else
-            echo "generating self-signed keys in /config/keys, you can replace these with your own keys if required"
-            openssl req -newkey rsa:2048 -new -x509 -days 9131 -nodes -sha256 \
-                -subj "/CN=meet.jitsi" \
-                -reqexts SAN -extensions SAN \
-                -config <(cat /etc/ssl/openssl.cnf ; printf "\n[SAN]\nsubjectAltName=DNS:meet.jitsi") \
-                -out /config/keys/cert.crt -keyout /config/keys/cert.key
-        fi
+        echo "generating self-signed keys in /config/keys, you can replace these with your own keys if required"
+        openssl req -newkey rsa:2048 -new -x509 -days 9131 -nodes -sha256 \
+            -subj "/CN=$XMPP_DOMAIN" \
+            -reqexts SAN -extensions SAN \
+            -config <(cat /etc/ssl/openssl.cnf ; printf "\n[SAN]\nsubjectAltName=DNS:$XMPP_DOMAIN") \
+            -out /config/keys/cert.crt -keyout /config/keys/cert.key
     fi
 fi
 
@@ -67,8 +66,16 @@ if [[ ! -f /config/nginx/ssl.conf ]]; then
     tpl /defaults/ssl.conf > /config/nginx/ssl.conf
 fi
 
+if [[ ! -f /config/nginx/ssl-local.conf ]]; then
+    tpl /defaults/ssl-local.conf > /config/nginx/ssl-local.conf
+fi
+
 if [[ ! -f /config/nginx/site-confs/default ]]; then
     tpl /defaults/default > /config/nginx/site-confs/default
+fi
+
+if [[ ! -f /config/nginx/site-confs/local ]]; then
+    tpl /defaults/local > /config/nginx/site-confs/local
 fi
 
 if [[ ! -f /config/config.js ]]; then


### PR DESCRIPTION
[As I commented here](https://github.com/jitsi/docker-jitsi-meet/pull/420#issuecomment-615303830), the current approach does not provide a self-signed cert for jibri to communicate internally if the server is using letsencrypt.

My proposal is to always have a self-signed cert with an own server block to receive local (`meet.jitsi`) requests.

Current issues/dependencies for this approach is:
 - For some reason, the command `openssl s_client -showcerts -connect meet.jitsi:443 < /dev/null` inside the jibri container does not give me the self-signed cert, it points to the default_server block on nginx which is set to the letsencrypt cert. I don't know why, because if I perform the same command locally (outside docker) I get the self-signed cert.
 - Still missing the CORS settings for meet.jitsi to communicate with the public url (should be configured at meet.conf)

I was able to make it work by manually adjusting the missing dependencies above.